### PR TITLE
Redirect svt.github.io/vivict to vivictorg.github.io/vivict

### DIFF
--- a/static/vivict/index.html
+++ b/static/vivict/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://vivictorg.github.io/vivict</title>
+<meta http-equiv="refresh" content="5; https://vivictorg.github.io/vivict">
+<link rel="canonical" href="https://vivictorg.github.io/vivict">
+
+<body>
+  Vivict has moved to https://vivictorg.github.io/vivict.
+<br /><br />
+  <a href="https://vivictorg.github.io/vivict">Click here
+    if you are not automatically redirected.
+</body>


### PR DESCRIPTION
Since the vivict repo has moved, the old github pages address needs to be redirected to the new address.

Signed-off-by: Gustav Grusell <gustav.grusell@gmail.com>